### PR TITLE
Some minor tweaks to improve experience

### DIFF
--- a/common/src/main/java/vice/sol_valheim/FoodHUD.java
+++ b/common/src/main/java/vice/sol_valheim/FoodHUD.java
@@ -88,7 +88,7 @@ public class FoodHUD implements ClientGuiEvent.RenderHud
         int startWidth = width - (size * offset) - offset + 1;
         float ticksLeftPercent = Float.min(1.0F, (float) food.ticksLeft / foodConfig.getTime());
         int barHeight = Integer.max(1, (int)((size + 2f) * ticksLeftPercent));
-        int barColor = ticksLeftPercent < SOLValheim.Config.common.eatAgainPercentage ?
+        int barColor = ticksLeftPercent < 0.2 ?
                 FastColor.ARGB32.color(180, 255, 10, 10) :
                 FastColor.ARGB32.color(96, 0, 0, 0);
 

--- a/common/src/main/java/vice/sol_valheim/mixin/LocalPlayerMixin.java
+++ b/common/src/main/java/vice/sol_valheim/mixin/LocalPlayerMixin.java
@@ -21,7 +21,7 @@ public class LocalPlayerMixin
         var solPlayer = (PlayerEntityMixinDataAccessor) this;
         var mayFly = ((LocalPlayer) (Object) this).getAbilities().mayfly;
 
-        if (mayFly || ((LocalPlayer) (Object) this).tickCount < SOLValheim.Config.common.respawnGracePeriod * 20)
+        if (mayFly || SOLValheim.Config.common.respawnGracePeriod < 0 || ((LocalPlayer) (Object) this).tickCount < SOLValheim.Config.common.respawnGracePeriod * 20)
         {
             return true;
         }
@@ -42,7 +42,7 @@ public class LocalPlayerMixin
         var solPlayer = (PlayerEntityMixinDataAccessor) this;
         var mayFly = ((LocalPlayer) (Object) this).getAbilities().mayfly;
 
-        if (mayFly || ((LocalPlayer) (Object) this).tickCount < SOLValheim.Config.common.respawnGracePeriod * 20)
+        if (mayFly || SOLValheim.Config.common.respawnGracePeriod < 0 || ((LocalPlayer) (Object) this).tickCount < SOLValheim.Config.common.respawnGracePeriod * 20)
         {
             cir.setReturnValue(true);
             cir.cancel();

--- a/common/src/main/java/vice/sol_valheim/mixin/PlayerEntityMixin.java
+++ b/common/src/main/java/vice/sol_valheim/mixin/PlayerEntityMixin.java
@@ -99,6 +99,8 @@ public abstract class PlayerEntityMixin extends LivingEntity implements PlayerEn
         }
 
         float maxhp = Math.min(40, (SOLValheim.Config.common.startingHealth * 2) + sol_valheim$food_data.getTotalFoodNutrition());
+        if (((int)maxhp % 2) != 0)
+            maxhp += 1;
 
         Player player = (Player) (LivingEntity) this;
         player.getFoodData().setSaturation(0);

--- a/common/src/main/java/vice/sol_valheim/mixin/PlayerEntityMixin.java
+++ b/common/src/main/java/vice/sol_valheim/mixin/PlayerEntityMixin.java
@@ -99,8 +99,8 @@ public abstract class PlayerEntityMixin extends LivingEntity implements PlayerEn
         }
 
         float maxhp = Math.min(40, (SOLValheim.Config.common.startingHealth * 2) + sol_valheim$food_data.getTotalFoodNutrition());
-        if (((int)maxhp % 2) != 0)
-            maxhp += 1;
+        // hack: round to full hearts
+        maxhp = Math.round(maxhp / 2) * 2;
 
         Player player = (Player) (LivingEntity) this;
         player.getFoodData().setSaturation(0);


### PR DESCRIPTION
Adds some minor tweaks to improve the gameplay experience a little:  
- Hunger bars will only turn red when there is 20% remaining (hardcoded) on the food item rather than when the food can be eaten again  
  Red usually indicates that something is running out, it was causing visual misinformation with a higher eat again percentage
- Set respawnGracePeriod below 0 for an infinite grace period, allowing one to sprint indefinitely even without food, fixes #14   
  This should arguably be a separate option to permanently allow sprinting, but -1 usually means infinite so it should be alright!
- Max health is rounded to the nearest full heart, fixes #17 