### PR TITLE
Fix drinks not ticking or displaying when there are no food.

### DIFF
--- a/common/src/main/java/vice/sol_valheim/mixin/PlayerEntityMixin.java
+++ b/common/src/main/java/vice/sol_valheim/mixin/PlayerEntityMixin.java
@@ -93,7 +93,7 @@ public abstract class PlayerEntityMixin extends LivingEntity implements PlayerEn
             return;
         }
 
-        if (!sol_valheim$food_data.ItemEntries.isEmpty()) {
+        if (!sol_valheim$food_data.ItemEntries.isEmpty() || sol_valheim$food_data.DrinkSlot != null) {
             sol_valheim$food_data.tick();
             sol_valheim$trackData();
         }


### PR DESCRIPTION
Not sure if this was intentional. If it was, the current implementation had the side effect of drinks not ticking or displaying during gameplay while also still having its effects active. 